### PR TITLE
Dependency-update of discord4j (use 3.2.1 instead of 3.1.x)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,13 +23,14 @@ ext {
         jdk_javadoc = "https://docs.oracle.com/en/java/javase/$jdk/docs/api/".toString()
     }
 
-    discord4j_core_version = '3.1.8'
-    stores_redis_version = '3.1.8'
+    discord4j_core_version = '3.2.1'
+    stores_redis_version = '3.2.1'
     rsocket_version = '1.0.5'
     rabbitmq_version = '1.4.5.RELEASE'
+    amqp_version = '5.13.1'
     jsr305_version = '3.0.2'
     junit_version = '4.13'
-    logback_version = '1.2.3'
+    logback_version = '1.2.10'
 
     isJitpack = "true" == System.getenv("JITPACK")
     isRelease = !version.toString().endsWith('-SNAPSHOT')

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     api project(':rsocket')
     api project(':rabbitmq')
 
+    implementation "com.rabbitmq:amqp-client:$amqp_version"
     implementation "ch.qos.logback:logback-classic:$logback_version"
     implementation "com.discord4j:discord4j-core:$discord4j_core_version"
     implementation "com.discord4j:stores-redis:$stores_redis_version"

--- a/examples/src/main/java/discord4j/connect/Constants.java
+++ b/examples/src/main/java/discord4j/connect/Constants.java
@@ -17,13 +17,52 @@
 
 package discord4j.connect;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
 public final class Constants {
 
+
     // TODO: use env variables?
+    // also better for kubernetes
+
+    // rabbitmq variables
+    private static final String RABBITMQ_HOST_INTERNAL = System.getenv("RABBITMQ_HOST");
+    public static final String RABBITMQ_HOST = (null == RABBITMQ_HOST_INTERNAL || RABBITMQ_HOST_INTERNAL.isEmpty()) ? "": RABBITMQ_HOST_INTERNAL;
+    // internal default in rabbitmq : -1
+    public static final String RABBITMQ_PORT_INTERNAL = System.getenv("RABBITMQ_PORT");
+    public static int RABBITMQ_PORT;
+    static {
+        try {
+            RABBITMQ_PORT = (null == RABBITMQ_PORT_INTERNAL || RABBITMQ_PORT_INTERNAL.isEmpty()) ? -1 : Integer.parseInt(RABBITMQ_PORT_INTERNAL);
+        } catch (NumberFormatException e) {
+            RABBITMQ_PORT = -1;
+        }
+    }
+
+    // rsocket variables
+    private static String LOCALHOST;
+    static {
+        try {
+            LOCALHOST = InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException e) {
+            LOCALHOST = "0.0.0.0";
+        }
+    }
+    private static final String RSOCKET_ROUTER_HOST = System.getenv("RSOCKET_ROUTER_HOST");
+    private static final String RSOCKET_SHARD_COORDINATOR_HOST = System.getenv("RSOCKET_SHARD_COORDINATOR_HOST");
+    private static final String RSOCKET_PAYLOAD_HOST = System.getenv("RSOCKET_PAYLOAD_HOST");
+
+    public static String GLOBAL_ROUTER_SERVER_HOST = (null == RSOCKET_ROUTER_HOST || RSOCKET_ROUTER_HOST.isEmpty()) ? LOCALHOST : RSOCKET_ROUTER_HOST;
+    public static String SHARD_COORDINATOR_SERVER_HOST = (null == RSOCKET_SHARD_COORDINATOR_HOST || RSOCKET_SHARD_COORDINATOR_HOST.isEmpty()) ? LOCALHOST : RSOCKET_SHARD_COORDINATOR_HOST;
+    public static String PAYLOAD_SERVER_HOST = (null == RSOCKET_PAYLOAD_HOST || RSOCKET_PAYLOAD_HOST.isEmpty()) ? LOCALHOST : RSOCKET_PAYLOAD_HOST;
     public static int GLOBAL_ROUTER_SERVER_PORT = 33331;
     public static int SHARD_COORDINATOR_SERVER_PORT = 33332;
     public static int PAYLOAD_SERVER_PORT = 33333;
-    public static String REDIS_CLIENT_URI = "redis://localhost:6379";
+
+    // redis variables
+    private static final String CLIENT_URI = System.getenv("REDIS_CLIENT_URI");
+    public static String REDIS_CLIENT_URI = (null == CLIENT_URI || CLIENT_URI.isEmpty()) ? "redis://localhost:6379" : CLIENT_URI;
 
     private Constants() {
     }

--- a/examples/src/main/java/discord4j/connect/ExampleSingleConnect.java
+++ b/examples/src/main/java/discord4j/connect/ExampleSingleConnect.java
@@ -1,5 +1,7 @@
 package discord4j.connect;
 
+import discord4j.common.store.Store;
+import discord4j.common.store.legacy.LegacyStoreLayout;
 import discord4j.connect.support.BotSupport;
 import discord4j.core.DiscordClientBuilder;
 import discord4j.core.GatewayDiscordClient;
@@ -9,10 +11,10 @@ import discord4j.store.jdk.JdkStoreService;
 public class ExampleSingleConnect {
 
     public static void main(String[] args) {
-        GatewayDiscordClient client = DiscordClientBuilder.create(System.getenv("token"))
+        GatewayDiscordClient client = DiscordClientBuilder.create(System.getenv("BOT_TOKEN"))
                 .build()
                 .gateway()
-                .setStoreService(new JdkStoreService())
+                .setStore(Store.fromLayout(LegacyStoreLayout.of(new JdkStoreService())))
                 .setSharding(ShardingStrategy.fixed(1))
                 .login()
                 .blockOptional()

--- a/examples/src/main/java/discord4j/connect/ExampleSingleWithConnection.java
+++ b/examples/src/main/java/discord4j/connect/ExampleSingleWithConnection.java
@@ -1,19 +1,19 @@
 package discord4j.connect;
 
+import discord4j.common.store.Store;
+import discord4j.common.store.legacy.LegacyStoreLayout;
 import discord4j.connect.support.BotSupport;
 import discord4j.core.DiscordClientBuilder;
-import discord4j.core.shard.InvalidationStrategy;
 import discord4j.core.shard.ShardingStrategy;
 import discord4j.store.jdk.JdkStoreService;
 
 public class ExampleSingleWithConnection {
 
     public static void main(String[] args) {
-        DiscordClientBuilder.create(System.getenv("token"))
+        DiscordClientBuilder.create(System.getenv("BOT_TOKEN"))
                 .build()
                 .gateway()
-                .setStoreService(new JdkStoreService())
-                .setInvalidationStrategy(InvalidationStrategy.disable())
+                .setStore(Store.fromLayout(LegacyStoreLayout.of(new JdkStoreService())))
                 .setSharding(ShardingStrategy.fixed(1))
                 .withGateway(client -> BotSupport.create(client).eventHandlers())
                 .block();

--- a/examples/src/main/java/discord4j/connect/rsocket/shared/ExampleRSocketLeader.java
+++ b/examples/src/main/java/discord4j/connect/rsocket/shared/ExampleRSocketLeader.java
@@ -18,6 +18,8 @@
 package discord4j.connect.rsocket.shared;
 
 import discord4j.common.JacksonResources;
+import discord4j.common.store.Store;
+import discord4j.common.store.legacy.LegacyStoreLayout;
 import discord4j.connect.Constants;
 import discord4j.connect.common.ConnectGatewayOptions;
 import discord4j.connect.common.UpstreamGatewayClient;
@@ -32,8 +34,8 @@ import discord4j.connect.rsocket.shard.RSocketShardCoordinator;
 import discord4j.core.DiscordClient;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.event.dispatch.DispatchEventMapper;
-import discord4j.core.shard.InvalidationStrategy;
 import discord4j.core.shard.ShardingStrategy;
+import discord4j.store.jdk.JdkStoreService;
 import discord4j.store.redis.RedisStoreService;
 import io.lettuce.core.RedisClient;
 import reactor.core.publisher.Mono;
@@ -61,12 +63,12 @@ public class ExampleRSocketLeader {
 
     public static void main(String[] args) {
 
-        // define the port where the global router is listening to
-        // define the port where the shard coordinator is listening to
-        // define the port where the payload server is listening to
-        InetSocketAddress globalRouterServerAddress = new InetSocketAddress(Constants.GLOBAL_ROUTER_SERVER_PORT);
-        InetSocketAddress coordinatorServerAddress = new InetSocketAddress(Constants.SHARD_COORDINATOR_SERVER_PORT);
-        InetSocketAddress payloadServerAddress = new InetSocketAddress(Constants.PAYLOAD_SERVER_PORT);
+        // define the host and port where the global router is listening to
+        // define the host and port where the shard coordinator is listening to
+        // define the host and port where the payload server is listening to
+        InetSocketAddress globalRouterServerAddress = new InetSocketAddress(Constants.GLOBAL_ROUTER_SERVER_HOST, Constants.GLOBAL_ROUTER_SERVER_PORT);
+        InetSocketAddress coordinatorServerAddress = new InetSocketAddress(Constants.SHARD_COORDINATOR_SERVER_HOST, Constants.SHARD_COORDINATOR_SERVER_PORT);
+        InetSocketAddress payloadServerAddress = new InetSocketAddress(Constants.PAYLOAD_SERVER_HOST, Constants.PAYLOAD_SERVER_PORT);
 
         // use a common jackson factory to reuse it where possible
         JacksonResources jackson = JacksonResources.create();
@@ -95,24 +97,26 @@ public class ExampleRSocketLeader {
         // RSocketPayloadSink: payloads leaders send to workers through the payload server
         // RSocketPayloadSource: payloads workers send to leaders through the payload server
         // we use UpstreamGatewayClient that is capable of using above components to work in a distributed way
-        GatewayDiscordClient client = DiscordClient.builder(System.getenv("token"))
+        GatewayDiscordClient client = DiscordClient.builder(System.getenv("BOT_TOKEN"))
                 .setJacksonResources(jackson)
-                .setGlobalRateLimiter(new RSocketGlobalRateLimiter(globalRouterServerAddress))
+                .setGlobalRateLimiter(RSocketGlobalRateLimiter.createWithServerAddress(globalRouterServerAddress))
                 .setExtraOptions(o -> new RSocketRouterOptions(o, request -> globalRouterServerAddress))
                 .build(RSocketRouter::new)
                 .gateway()
                 .setSharding(recommendedStrategy)
-                .setShardCoordinator(new RSocketShardCoordinator(coordinatorServerAddress))
+                .setShardCoordinator(RSocketShardCoordinator.createWithServerAddress(coordinatorServerAddress))
 //                .setDisabledIntents(IntentSet.of(
 //                        Intent.GUILD_PRESENCES,
 //                        Intent.GUILD_MESSAGE_TYPING,
 //                        Intent.DIRECT_MESSAGE_TYPING))
 //                .setInitialStatus(s -> Presence.invisible())
-                .setInvalidationStrategy(InvalidationStrategy.disable())
-                .setStoreService(RedisStoreService.builder()
+
+//                .setInvalidationStrategy(InvalidationStrategy.disable())
+
+                .setStore(Store.fromLayout(LegacyStoreLayout.of(RedisStoreService.builder()
                         .redisClient(redisClient)
                         .useSharedConnection(false)
-                        .build())
+                        .build())))
                 .setDispatchEventMapper(DispatchEventMapper.discardEvents())
                 .setExtraOptions(o -> new ConnectGatewayOptions(o,
                         new RSocketPayloadSink(payloadServerAddress,
@@ -128,13 +132,11 @@ public class ExampleRSocketLeader {
                 .port(0) // use an ephemeral port
                 .route(routes -> routes
                         .get("/logout",
-                                (req, res) -> {
-                                    return client.logout()
-                                            .then(Mono.from(res.addHeader("content-type", "application/json")
-                                                    .status(200)
-                                                    .chunkedTransfer(false)
-                                                    .sendString(Mono.just("OK"))));
-                                })
+                                (req, res) -> client.logout()
+                                        .then(Mono.from(res.addHeader("content-type", "application/json")
+                                                .status(200)
+                                                .chunkedTransfer(false)
+                                                .sendString(Mono.just("OK")))))
                 )
                 .bind()
                 .doOnNext(facade -> {
@@ -142,7 +144,7 @@ public class ExampleRSocketLeader {
                     log.info("Server started at {}:{}", facade.host(), facade.port());
                     log.info("*************************************************************");
                     // kill the server on JVM exit
-                    Runtime.getRuntime().addShutdownHook(new Thread(() -> facade.disposeNow()));
+                    Runtime.getRuntime().addShutdownHook(new Thread(facade::disposeNow));
                 })
                 .subscribe();
 

--- a/examples/src/main/java/discord4j/connect/rsocket/shared/ExampleRSocketLeader.java
+++ b/examples/src/main/java/discord4j/connect/rsocket/shared/ExampleRSocketLeader.java
@@ -144,7 +144,7 @@ public class ExampleRSocketLeader {
                     log.info("Server started at {}:{}", facade.host(), facade.port());
                     log.info("*************************************************************");
                     // kill the server on JVM exit
-                    Runtime.getRuntime().addShutdownHook(new Thread(facade::disposeNow));
+                    Runtime.getRuntime().addShutdownHook(new Thread(() -> facade.disposeNow()));
                 })
                 .subscribe();
 

--- a/examples/src/main/java/discord4j/connect/support/BotSupport.java
+++ b/examples/src/main/java/discord4j/connect/support/BotSupport.java
@@ -6,7 +6,7 @@ import discord4j.core.event.domain.lifecycle.ReadyEvent;
 import discord4j.core.event.domain.message.MessageCreateEvent;
 import discord4j.core.object.entity.Message;
 import discord4j.core.object.entity.User;
-import discord4j.core.object.presence.Presence;
+import discord4j.core.object.presence.ClientPresence;
 import discord4j.discordjson.json.ApplicationInfoData;
 import discord4j.discordjson.json.ImmutableMessageCreateRequest;
 import discord4j.discordjson.possible.Possible;
@@ -106,6 +106,10 @@ public class BotSupport {
                                         .blockOptional()
                                         .orElse(-1L)
                                         .toString(), false);
+                                spec.addField("Application-Info", event.getClient().getApplicationInfo()
+                                    .blockOptional()
+                                    .orElseThrow(RuntimeException::new)
+                                    .toString(), false);
                             })))
                     .then();
         }
@@ -121,13 +125,13 @@ public class BotSupport {
                     .map(content -> {
                         String status = content.substring("!status ".length());
                         if (status.equalsIgnoreCase("online")) {
-                            return Presence.online();
+                            return ClientPresence.online();
                         } else if (status.equalsIgnoreCase("dnd")) {
-                            return Presence.doNotDisturb();
+                            return ClientPresence.doNotDisturb();
                         } else if (status.equalsIgnoreCase("idle")) {
-                            return Presence.idle();
+                            return ClientPresence.idle();
                         } else if (status.equalsIgnoreCase("invisible")) {
-                            return Presence.invisible();
+                            return ClientPresence.invisible();
                         } else {
                             throw new IllegalArgumentException("Invalid argument");
                         }

--- a/rabbitmq/build.gradle
+++ b/rabbitmq/build.gradle
@@ -2,5 +2,6 @@ dependencies {
     api project(':common')
     api "io.projectreactor.rabbitmq:reactor-rabbitmq:$rabbitmq_version"
 
+    implementation "com.rabbitmq:amqp-client:$amqp_version"
     implementation "com.discord4j:discord4j-core:$discord4j_core_version"
 }

--- a/rsocket/src/main/java/discord4j/connect/rsocket/router/RSocketRouterOptions.java
+++ b/rsocket/src/main/java/discord4j/connect/rsocket/router/RSocketRouterOptions.java
@@ -49,7 +49,8 @@ public class RSocketRouterOptions extends RouterOptions {
                 parent.getExchangeStrategies(),
                 parent.getResponseTransformers(),
                 parent.getGlobalRateLimiter(),
-                parent.getRequestQueueFactory());
+                parent.getRequestQueueFactory(),
+                parent.getDiscordBaseUrl());
 
         this.requestTransportMapper = Objects.requireNonNull(requestTransportMapper, "requestTransportMapper");
     }


### PR DESCRIPTION
There are problems with compatibility between connect 0.6.8 and  discord4j 3.2.1.
For example the following error occured:

```
2022-03-12 23:38:35.345 main DEBUG o.s.b.a.ApplicationAvailabilityBean - Application availability state ReadinessState changed to ACCEPTING_TRAFFIC
Exception in thread "main" java.lang.reflect.InvocationTargetException
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
at java.base/java.lang.reflect.Method.invoke(Unknown Source)
at org.springframework.boot.loader.MainMethodRunner.run(MainMethodRunner.java:49)
at org.springframework.boot.loader.Launcher.launch(Launcher.java:108)
at org.springframework.boot.loader.Launcher.launch(Launcher.java:58)
at org.springframework.boot.loader.JarLauncher.main(JarLauncher.java:88)
Caused by: java.lang.NoSuchMethodError: 'void discord4j.rest.request.RouterOptions.<init>(java.lang.String, discord4j.common.ReactorResources, discord4j.rest.http.ExchangeStrategies, java.util.List, discord4j.rest.request.GlobalRateLimiter, discord4j.rest.request.RequestQueueFactory)'
at discord4j.connect.rsocket.router.RSocketRouterOptions.<init>(RSocketRouterOptions.java:47)
```
So i updated the connect-library myself, hope it will be ok. Also the examples are tested and adapted.